### PR TITLE
fix: load model add m_id_to_string

### DIFF
--- a/Alphabet.h
+++ b/Alphabet.h
@@ -156,6 +156,7 @@ public:
 		for (int i = 0; i < m_size; ++i) {
 			inf >> featKey >> featId;
 			m_string_to_id[featKey] = i;
+			m_id_to_string.push_back(featKey);
 			assert(featId == i);
 		}
 		if (m_size > 0) {


### PR DESCRIPTION
Alphabet load model add init m_id_to_string.
Program will crash when saving a new model if training is based on an exist model.